### PR TITLE
Vectorize pure nonlinear problems.

### DIFF
--- a/private/bent_beam.m
+++ b/private/bent_beam.m
@@ -134,33 +134,34 @@ F = @(z) [F1(z); F2(z); F3(z); F4(z); F5(z); F6(z)];
 end
 
 function F = bent_beam_fun(z)
-    
+
+z = z(:);
 l= 23.5;
 EI = 38.92e3;
 m = 1.833e-4;
 tau = 4.93e4;
       
 % Building the functions
-fun11 =  cosh(l*(m/EI)^(0.25)*sqrt(z));
-fun12 =  (m/EI)^(0.25)*sqrt(z)*cosh(l*(m/EI)^(0.25)* ...
+fun11 =  cosh(l.*(m/EI).^(0.25).*sqrt(z));
+fun12 =  (m/EI).^(0.25).*sqrt(z).*cosh(l.*(m/EI).^(0.25).* ...
                                         sqrt(z));
-fun13 =  (m/EI)^(0.5)*z*cosh(l*(m/EI)^(0.25)*sqrt(z));
-fun21 =  cos(l*(m/EI)^(0.25)*sqrt(z));
-fun22 =  (m/EI)^(0.25)*sqrt(z)*cos(l*(m/EI)^(0.25)* ...
+fun13 =  (m/EI).^(0.5).*z.*cosh(l.*(m/EI).^(0.25).*sqrt(z));
+fun21 =  cos(l.*(m/EI).^(0.25).*sqrt(z));
+fun22 =  (m/EI).^(0.25).*sqrt(z).*cos(l.*(m/EI).^(0.25).* ...
                                        sqrt(z));
-fun23 =  (m/EI)^(0.5)*z*cos(l*(m/EI)^(0.25)*sqrt(z));
-fun31 =  sinh(l*(m/EI)^(0.25)*sqrt(z));
-fun32 =  (m/EI)^(0.25)*sqrt(z)*sinh(l*(m/EI)^(0.25)* ...
+fun23 =  (m/EI).^(0.5).*z.*cos(l.*(m/EI).^(0.25).*sqrt(z));
+fun31 =  sinh(l.*(m/EI).^(0.25).*sqrt(z));
+fun32 =  (m/EI).^(0.25).*sqrt(z).*sinh(l.*(m/EI).^(0.25).* ...
                                         sqrt(z));
-fun33 =  (m/EI)^(0.5)*z*sinh(l*(m/EI)^(0.25)*sqrt(z));
-fun41 =  sin(l*(m/EI)^(0.25)*sqrt(z));
-fun42 =  (m/EI)^(0.25)*sqrt(z)*sin(l*(m/EI)^(0.25)* ...
+fun33 =  (m/EI).^(0.5).*z.*sinh(l.*(m/EI).^(0.25).*sqrt(z));
+fun41 =  sin(l.*(m/EI).^(0.25).*sqrt(z));
+fun42 =  (m/EI).^(0.25).*sqrt(z).*sin(l.*(m/EI).^(0.25).* ...
                                        sqrt(z));
-fun43 =  (m/EI)^(0.5)*z*sin(l*(m/EI)^(0.25)*sqrt(z));
-fun51 =  cos(l*(m/tau)^(0.5)*z);
-fun52 =  (m/tau)^(0.5)*z*cos(l*(m/tau)^(0.5)*z);
-fun61 =  sin(l*(m/tau)^(0.5)*z);
-fun62 =  (m/tau)^(0.5)*z*sin(l*(m/tau)^(0.5)*z);
+fun43 =  (m/EI).^(0.5).*z.*sin(l.*(m/EI).^(0.25).*sqrt(z));
+fun51 =  cos(l.*(m/tau).^(0.5).*z);
+fun52 =  (m/tau).^(0.5).*z.*cos(l.*(m/tau).^(0.5).*z);
+fun61 =  sin(l.*(m/tau).^(0.5).*z);
+fun62 =  (m/tau).^(0.5).*z.*sin(l.*(m/tau).^(0.5).*z);
     
 F =  [fun11, fun12, fun13, fun21, fun22, fun23, fun31, fun32, fun33,  ...
       fun41, fun42, fun43, fun51, fun52, fun61, fun62];

--- a/private/canyon_particle.m
+++ b/private/canyon_particle.m
@@ -178,10 +178,10 @@ end
 %% nonlinear functions
 f = cell(length(brpts),1);
 for j = 1:interval-1
-     f{j} = @(lambda) expm(1i*sqrtm(m*(lambda-brpts(j)*lambda^0)));
+     f{j} = @(lambda) exp(1i.*(m.*(lambda-brpts(j))).^(0.5));
 end
 for j = interval:length(brpts)
-     f{j} = @(lambda) expm(-sqrtm(m*(-lambda+brpts(j)*lambda^0)));
+     f{j} = @(lambda) exp(-(m.*(-lambda+brpts(j))).^(0.5));
 end
 
 % Setting coeffs
@@ -202,11 +202,12 @@ end
 
 
 function fun = canyon_particle_fun(lam, f)
+lam = lam(:);
 N = length(f);
-fun = zeros(1,N+2);
-fun(1:2) = [1 -lam];
+fun = zeros(length(lam), N+2);
+fun(:,1:2) = [ones(length(lam),1) -lam];
 for k = 1:N
-    fun(k+2) = -f{k}(lam);
+    fun(:,k+2) = -f{k}(lam);
 end  
 end
 

--- a/private/nep1.m
+++ b/private/nep1.m
@@ -31,12 +31,12 @@ function varargout = nep1_fun(lam)
 lam = lam(:);
 n = length(lam);
 
-varargout{1} = [ones(n,1), exp(1i*lam^2)];
+varargout{1} = [ones(n,1), exp(1i*lam.^2)];
 if nargout >= 2
-    f = 2*1i*lam*exp(1i*lam^2);
+    f = 2*1i*lam.*exp(1i*lam.^2);
     varargout{2} = [zeros(n,1),f];
     for k = 2:nargout-1
-        f = 1i*lam*f;
+        f = 1i.*lam.*f;
         varargout{k+1} = [zeros(n,2),f];
     end
 end

--- a/private/nep2.m
+++ b/private/nep2.m
@@ -41,17 +41,17 @@ F = @(z) [2*exp(z)+cos(z)-14 (z^2-1)*sin(z)+ ...
 end
 
 function F = nep2_fun(z)
-
+z = z(:);
 f0 = z;
 f1 = exp(z);
 f2 = z.*exp(z);
 f3 = exp(z).*cos(z);
 f4 = z.*exp(z).*cos(z);
 f5 = cos(z);
-f6 = z*cos(z);
+f6 = z.*cos(z);
 f7 = sin(z);
 f8 = z.^2.*sin(z);
-f9 = 1;
+f9 = ones(size(z));
   
 F = [f0 f1 f2 f3 f4 f5 f6 f7 f8 f9];
 end


### PR DESCRIPTION
This pull request addresses a small bug concerning the pure nonlinear problems. Running 

`[coeffs, fun] = nlevp('bent_beam');
fun([1 2]);`

produces an error. This has been fixed.
